### PR TITLE
Remove renovate.json; drop actions/checkout SHA pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       name: "release"
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v6
       - name: Build python package
         run: python3 setup.py sdist
       - name: Publish python package to PyPI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@v6
     - name: test
       run: |
         sudo apt-get update && sudo apt-get dist-upgrade && sudo apt-get install python3-dev && \

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ],
-  "ignorePaths": []
-}


### PR DESCRIPTION
Converging the org on Dependabot, plus rolling in a workflow hygiene fix in the same PR to keep churn down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)